### PR TITLE
Update production code based on review comments

### DIFF
--- a/en/details.html
+++ b/en/details.html
@@ -44,7 +44,7 @@
   </div>
   <div class="row">
     <div class="small-9 medium-9 large-9 columns">
-      <h4>Provide an rpc-style raw HTTP service</h4>
+      <h4>HTTP Input to drive a message flow</h4>
     </div>
     <div class="small-3 medium-3 large-3 columns"> 
       <!--a href="javascript:;" onclick="openHelpSystem('com.ibm.etools.mft.doc/ac56650_.htm');" class="small right helplink">Processing HTTP messages</a-->
@@ -53,7 +53,7 @@
   <hr>
   <div class="row">
     <div class="small-12 medium-12 large-12 columns">
-      <h5> Learn how to use HTTPInput and HTTPReply nodes to handle raw rpc-style requests over http </h5>
+      <h5> Learn how to use HTTPInput and HTTPReply nodes to expose an http URL that can drive a message flow </h5>
     </div>
   </div>
   <div class="row content-details">
@@ -66,11 +66,13 @@
         
         <p> In IBM Integration Bus, you have several options on how to create an HTTP interface to external programs. </p>
       
-        <p> If you want to use a standard interface definition, there are specialised development artefacts which simplify that process.  If you use WSDL for Web Service interactions then create an Integration Service, and if you use Swagger to define REST-style actions over a set of resources then create a REST API. </p>
+        <p> If you want to use a standard interface definition, there are specialised development artefacts which simplify that process.  If you use WSDL for Web Service interactions then create an Integration Service, and if you use Swagger to define REST-style actions over a set of resources then create a REST API.  In both of those cases, you can concentrate on implementing handlers for a particular request and the container handles the routing. </p>
       
-        <p> However there are some http interactions which don&#39;t fit either of these categories. This tutorial shows how to create an RPC-style interaction over raw HTTP, where all requests to a particular URL are routed to a message flow for processing. In this case, the processing is a transformation step using a Mapping node. </p>
+        <p> See the Integration Services or REST tutorials for those examples. </p>
       
-        <p> You will import the message flow to your Integration Toolkit workspace, and send an HTTP request to the message flow by using the Flow exerciser. </p>
+        <p> However there are some http integration requirements which don&#39;t fit either of these categories. This tutorial shows how to create a message flow which listens for any http request on a particular URL. The request is processed directly by the message flow and an http response is built. In this case, the processing is a transformation step using a Mapping node. </p>
+      
+        <p> You will import the message flow to your Integration Toolkit workspace, and send an HTTP request to the message flow by using the Flow exerciser, and observe how that request is represented in a message flow. </p>
       
       </div>	  
 		<!-- help links do not work in details page for GA 

--- a/en/steps.html
+++ b/en/steps.html
@@ -44,7 +44,7 @@
 	</div>
 	<div class="row">
 	  <div class="small-9 medium-9 large-9 columns">
-	    <h4 class="title">Provide an rpc-style raw HTTP service <action><div class="small radius button" id="stepsViewDetails" onclick="viewDetails()"> View Details</div> </action></h4>
+	    <h4 class="title">HTTP Input to drive a message flow <action><div class="small radius button" id="stepsViewDetails" onclick="viewDetails()"> View Details</div> </action></h4>
 	  </div>
 	  <div class="small-3 medium-3 large-3 columns">
 		<a href="javascript:;" onclick="openHelpSystem('com.ibm.etools.mft.doc/ac56650_.htm')" class="small right helplink">Processing HTTP messages</a> 
@@ -53,7 +53,7 @@
 	<hr>
 	<div class="row">
 		<div class="small-10 medium-10 large-10 columns">
-		<h5> Learn how to use HTTPInput and HTTPReply nodes to handle raw rpc-style requests over http </h5>
+		<h5> Learn how to use HTTPInput and HTTPReply nodes to expose an http URL that can drive a message flow </h5>
 		</div>
 		<div class="small-2 medium-2 large-2 columns">
 			<div class="small radius button right" id="backToGallery" onclick="backToGallery()"> Back To Gallery


### PR DESCRIPTION
A further pull request to update the production html code used in the toolkit.  This is to remove mention of rpc-style and bring the tutorial description back in line with the master branch in repo-metadata.json. Have tested on Windows toolkit.
